### PR TITLE
Fixes #2 Problem with extensions and aliased class names

### DIFF
--- a/Dolphin to Pharo/DolphinMethodChunk.class.st
+++ b/Dolphin to Pharo/DolphinMethodChunk.class.st
@@ -4,6 +4,13 @@ Class {
 	#category : #'Dolphin to Pharo'
 }
 
+{ #category : #accessing }
+DolphinMethodChunk >> behaviorName: aBehaviorName [
+	"If the arguement is an alias first try to convert to the aliased name."
+	super behaviorName: aBehaviorName.
+	self class environment at: aBehaviorName ifPresent: [:behavior | behaviorName := behavior name ]
+]
+
 { #category : #importing }
 DolphinMethodChunk >> importFor: requestor logSource: aBoolean [
 

--- a/Dolphin to Pharo/DolphinPackageMethodNames.class.st
+++ b/Dolphin to Pharo/DolphinPackageMethodNames.class.st
@@ -14,11 +14,11 @@ DolphinPackageMethodNames >> add: anAssociation [
 
 	(anAssociation key includes: Character space)
 	ifTrue: 
-			[className := anAssociation key readStream upTo: $ .
+			[className := (self class environment at: (anAssociation key readStream upTo: $ )) name.
 			 self package addSelector: anAssociation value ofMetaclassName: className ]
 	ifFalse: 
-			[className := anAssociation key.
-			 self package addSelector: anAssociation value ofClassName: anAssociation key ].
+			[className := (self class environment at: anAssociation key) name.
+			 self package addSelector: anAssociation value ofClassName: className ].
 		
 	self package organizer registerExtendingPackage: package forClassName: className
 ]

--- a/Dolphin to Pharo/RPackage.extension.st
+++ b/Dolphin to Pharo/RPackage.extension.st
@@ -89,6 +89,7 @@ RPackage class >> name: aString [
 	
 	dolphinPackage := self named: aString.
 	self currentDolphinPackage: dolphinPackage.
+	dolphinPackage register.
 	^dolphinPackage
 ]
 


### PR DESCRIPTION
Extension and method definitions should resolve to the aliased names.
Packages should be registered on creation.